### PR TITLE
#166789879 Pagination support for article's ratings

### DIFF
--- a/src/controllers/articleRatingControllers.js
+++ b/src/controllers/articleRatingControllers.js
@@ -1,4 +1,5 @@
 import model from '../db/models/index';
+import paginate from '../helpers/paginate';
 
 const { Users, Articles, Rating } = model;
 
@@ -71,28 +72,30 @@ class ArticleRatingManager {
  * @returns {message} That article is not available
  */
   static async ratingAverage(req, res) {
-    const averageRating = await Rating.findAll({
-      where: { articleId: req.params.articleId },
-      attributes: ['rating'],
-      raw: true,
-    });
+    const pageNumber = paginate(req.query.page, req.query.pageSize);
+    const averageRating = await Rating.findAll({ where: { articleId: req.params.articleId }, attributes: ['rating'], raw: true, });
     if (!averageRating.length) {
-      return res.status(400).send({
-        message: 'The Article requested has not been rated yet'
-      });
+      return res.status(400).send({ message: 'The Article requested has not been rated yet' });
     }
     let totalrating = 0;
     averageRating.map((rating) => {
       totalrating += rating.rating;
       return averageRating;
     });
-    const average = (totalrating / averageRating.length).toFixed(1);
-    return res.status(200).send({
-      rating: {
-        average,
-        raters: averageRating.length
-      }
+    const userNames = await Rating.findAll({
+      offset: pageNumber.offset,
+      limit: pageNumber.limit,
+      include: [{ model: Users, attributes: ['username'], raw: true }]
     });
+    if (!userNames.length) {
+      return res.status(404).json({ error: 'The raters requested can not be found' });
+    }
+    const ratersNames = [];
+    for (let i = 0; i < userNames.length; i += 1) {
+      ratersNames.push(userNames[i].dataValues.User.dataValues.username);
+    }
+    const average = (totalrating / averageRating.length).toFixed(1);
+    return res.status(200).send({ rating: { average, raters: averageRating.length, ratersNames } });
   }
 }
 export default ArticleRatingManager;

--- a/swagger.json
+++ b/swagger.json
@@ -874,6 +874,20 @@
                         "schema": {
                             "$ref": "#/definitions/fecthratings"
                         }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "string",
+                        "description": "specify page",
+                        "require": true
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "type": "string",
+                        "description": "specify pageSize",
+                        "require": true
                     }
                 ],
                 "produces": [

--- a/tests/ratesTest.js
+++ b/tests/ratesTest.js
@@ -36,4 +36,22 @@ describe('Fetch Rating Routes', () => {
       });
     done();
   });
+  it('it should not fetch a rating when there is no srate', (done) => {
+    chai.request(index)
+      .get('/api/ratings/1/?page=4&pageSize=0')
+      .end((err, res) => {
+        res.status.should.equal(404);
+        res.body.should.be.a('object');
+      });
+    done();
+  });
+  it('it should not fetch a rating when there is no article', (done) => {
+    chai.request(index)
+      .get('/api/ratings/0/?page=4&pageSize=9')
+      .end((err, res) => {
+        res.status.should.equal(400);
+        res.body.should.be.a('object');
+      });
+    done();
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

 - Pagination support for article's ratings

#### Description of Task to be completed?

  - add a helper for article pagination
  - add test for the feature

#### How should this be manually tested?

When you access `/ratings/:articleId` to get ratings, you can choose which page you want to see and how many raters you want to see per page

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [#166789879](https://www.pivotaltracker.com/story/show/166789879)

#### Screenshots (if appropriate)
 ## 1. Mockups

![image](https://user-images.githubusercontent.com/48624152/61789931-37c9db00-ae16-11e9-9e89-82f2203620e2.png)

![image](https://user-images.githubusercontent.com/48624152/61792772-c55cf900-ae1d-11e9-9156-692c5350b42a.png)

## 2. Documentation

![image](https://user-images.githubusercontent.com/48624152/61789958-4b754180-ae16-11e9-9557-4dcee55ba7c3.png)

![image](https://user-images.githubusercontent.com/48624152/61789972-59c35d80-ae16-11e9-9ebf-7835a7c6fa6c.png)

![image](https://user-images.githubusercontent.com/48624152/61790007-6cd62d80-ae16-11e9-8f84-cc28281a610f.png)


#### Questions:

- N/A