### PR TITLE
bug(like-dislike): get all messages with their likes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,6 @@
 exclude_patterns:
 - "src/db/"
 - "tests/"
+checks:
+  similar-code:
+    enabled: false

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -5,7 +5,7 @@ import model from '../db/models/index';
 dotenv.config();
 
 const {
-  Comments, Articles, CommentEditHistory, Users
+  Comments, Articles, CommentEditHistory, Users, LikeDislikeComment
 } = model;
 
 /**
@@ -75,6 +75,11 @@ class CommentManager {
           as: 'User',
           model: Users,
           attributes: ['id', 'username', 'image']
+        },
+        {
+          as: 'comment',
+          model: LikeDislikeComment,
+          attributes: ['id', 'commentId', 'like', 'dislike']
         }
       ]
     });

--- a/src/controllers/likeDislikeComment.js
+++ b/src/controllers/likeDislikeComment.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import model from '../db/models/index';
 
 const { LikeDislikeComment, Comments } = model;
@@ -28,9 +29,12 @@ class LikeDislikeComments {
     if (!findComment) {
       return res.status(404).send({ error: 'The comment requested is not found!' });
     }
-    const find = await LikeDislikeComment.findOne({ where: { userId: req.user.id, like: true } });
+    /**
+     * find disliked
+     */
+    const find = await LikeDislikeComment.findOne({ where: { userId: req.user.id, like: true, commentId: like.commentId } });
     if (find) {
-      await LikeDislikeComment.update({ like: false }, { where: { userId: req.user.id } });
+      await LikeDislikeComment.update({ like: false }, { where: { userId: req.user.id, commentId: like.commentId } });
       const Likes = await LikeDislikeComment.findAll({ where: { like: true } });
       return res.status(201).json({
         message: 'You unliked this comment', data: dislikedComment, total: Likes.length
@@ -52,9 +56,9 @@ class LikeDislikeComments {
       like: false,
       dislike: true,
       userId: req.user.id,
-      commentId: req.body.id
+      commentId: req.params.id
     };
-    const find = await LikeDislikeComment.findOne({ where: { userId: req.user.id, like: true } });
+    const find = await LikeDislikeComment.findOne({ where: { userId: req.user.id, like: true, commentId: dislike.commentId } });
     if (find) {
       const { like: liked, dislike: disliked } = find;
       if (liked) await find.update({ like: false });

--- a/src/db/migrations/20190731123317-create-like-dislike-comment.js
+++ b/src/db/migrations/20190731123317-create-like-dislike-comment.js
@@ -12,7 +12,13 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       commentId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        onDelete: 'CASCADE',
+        references: {
+          model: 'Comments',
+          key: 'id'
+        }
       },
       like: {
         type: Sequelize.BOOLEAN

--- a/src/db/models/comments.js
+++ b/src/db/models/comments.js
@@ -18,6 +18,10 @@ export default (sequelize, DataTypes) => {
     }
   );
   Comments.associate = function (models) {
+    Comments.hasMany(models.LikeDislikeComment, {
+      as: 'comment',
+      foreignKey: 'commentId'
+    });
     Comments.belongsTo(models.Users, {
       foreignKey: 'user',
       onDelete: 'CASCADE'

--- a/src/db/models/likedislikecomment.js
+++ b/src/db/models/likedislikecomment.js
@@ -1,13 +1,23 @@
 'use strict';
-module.exports = (sequelize, DataTypes) => {
+export default (sequelize, DataTypes) => {
   const LikeDislikeComment = sequelize.define('LikeDislikeComment', {
-    userId: DataTypes.INTEGER,
-    commentId: DataTypes.INTEGER,
+    userId: {
+        type: DataTypes.INTEGER
+    },
+    commentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+    },
     like: DataTypes.BOOLEAN,
     dislike: DataTypes.BOOLEAN
   }, {});
   LikeDislikeComment.associate = function(models) {
     // associations can be defined here
+    LikeDislikeComment.belongsTo(models.Comments, {
+        as: 'comment',
+        foreignKey: 'commentId',
+        onDelete: 'CASCADE'
+    });
   };
   return LikeDislikeComment;
 };


### PR DESCRIPTION
#### What does this PR do?
- add the relationship of comments and like and dislike comment models
- include the likes object of the that model to the response

#### Description of Task to be completed?
- Should get all messages with their likes
#### How should this be manually tested?
- First clone it to your machine:
```
https://github.com/andela/ah-lobos-backend.git
```
- Open it using your favorite IDE, I recommend ([vs code](https://code.visualstudio.com/download))

- Install all necessary node modules
```
npm install
```
- Run
```
npm run dev
```
- Use Postman to test out the following endpoints
### API ENDPOINTS
| API | Methods  | Description  |
| ------- | --- | --- |
| `/api/comments/like/comment/:id` | POST | like a comment |
| `/api/comments/dislike/comment/:id` | Post | dislike a comment |

User should see likes on the comment
#### Any background context you want to provide?
- Create `.env` file with the help of `example.env`
#### What are the relevant pivotal tracker stories?
- N/A

#### Screenshots
- N/A
#### Questions
- N/A