### PR TITLE
Add get user notification preference

### DIFF
--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -13,7 +13,7 @@ class NotificationManager {
  * @returns {object} article
  */
   static async getNotifications(req, res) {
-    const notifications = await Notifications.findAll({ where: { userId: req.user.id, status: 'unseen' } });
+    const notifications = await Notifications.findAll({ where: { userId: req.user.id } });
     if (notifications.length === 0) {
       return res.status(404).json({ message: 'You are all caught up, you have zero notifications' });
     }
@@ -23,6 +23,18 @@ class NotificationManager {
       });
     });
     return res.status(200).json({ number: notifications.length, notifications });
+  }
+
+  /**
+ *
+ * @param {object} req
+ * @param {object} res
+ * @returns {object} article
+ */
+  static async getNotificationsConfig(req, res) {
+    const config = await NotificationConfigs.findOne({ where: { userId: req.user.id } });
+    const settings = JSON.parse(config.config);
+    return res.status(200).json({ settings });
   }
 
   /**

--- a/src/routes/api/notifications.js
+++ b/src/routes/api/notifications.js
@@ -6,6 +6,7 @@ import auth from '../../middlewares/auth';
 const router = express.Router();
 
 router.get('/', auth.checkAuthentication, notificationManager.getNotifications);
+router.get('/config', auth.checkAuthentication, notificationManager.getNotificationsConfig);
 router.put('/config', auth.checkAuthentication, ValidateConfig.notificationConfigSchema, notificationManager.updateConfig);
 
 export default router;

--- a/tests/notificationsTest.js
+++ b/tests/notificationsTest.js
@@ -53,6 +53,16 @@ describe('User notifications', () => {
         done();
       });
   });
+  it('A user should be able to get his or her notification preference', (done) => {
+    chai.request(index)
+      .get('/api/notifications/config')
+      .set('token', userToken2)
+      .end((err, res) => {
+        res.status.should.equal(200);
+        res.body.should.be.an('object');
+        done();
+      });
+  });
   it('A user should be able to update his or her notification preference', (done) => {
     const config = {
       inApp: true,


### PR DESCRIPTION
#### What does this PR do?
 This Pull Request adds an endpoint to give users the opportunity of getting their notification preferences

#### Description of Task to be completed?
 This Pull Request adds an endpoint to give users the opportunity of getting their notification preferences

#### How should this be manually tested?
### Database Setup (Postgres - Sequelize )
> install dependencies and development dependencies
```
> npm install
```

> create dataabase to postgresql
```
> createdb authorsHavenDb
```
remember to change the password in config.js file for development

> create your config file
```
> create a .env file in your root directory and follow the `example.env`
file in setting up yours
```

> add table to database

```
> sequelize db:migrate
```
The above command will migrate all table to your database

> remove all tables from the database

```
> sequelize db:migrate:undo
```
The above command will revert any migration.

#### Any background context you want to provide?
Prior to this addition, users could only retrieve unseen notifications and couldn't get their notification preferences

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A